### PR TITLE
Fixes date parsing dependent on user settings, like am/pm time format.

### DIFF
--- a/TPInAppReceipt/Source/Date+Extension.swift
+++ b/TPInAppReceipt/Source/Date+Extension.swift
@@ -10,19 +10,20 @@ import Foundation
 
 public extension Date
 {
-    public static func date(fromString string: String, dateFormat: String = "yyyy-MM-dd'T'HH:mm:ss'Z'", timeZone: TimeZone = TimeZone.autoupdatingCurrent) -> Date?
+    public static func rfc3339date(fromString string: String) -> Date?
     {
-        return string.date(withDateFormat: dateFormat, timeZone: timeZone)
+        return string.rfc3339date()
     }
 }
 
 public extension String
 {
-    public func date(withDateFormat dateFormat: String = "yyyy-MM-dd'T'HH:mm:ss'Z'", timeZone: TimeZone = TimeZone.autoupdatingCurrent) -> Date
+    public func rfc3339date() -> Date
     {
         let formatter = DateFormatter()
-        formatter.dateFormat = dateFormat
-        formatter.timeZone = timeZone
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        formatter.timeZone = TimeZone(abbreviation: "UTC")
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         
         let date = formatter.date(from: self)
         return date!

--- a/TPInAppReceipt/Source/InAppReceipt.swift
+++ b/TPInAppReceipt/Source/InAppReceipt.swift
@@ -216,14 +216,14 @@ public extension InAppPurchase
 {
     public var purchaseDate: Date
     {
-        return purchaseDateString.date()
+        return purchaseDateString.rfc3339date()
     }
     
     public var subscriptionExpirationDate: Date
     {
         assert(isRenewableSubscription, "\(productIdentifier) is not an auto-renewable subscription.")
         
-        return subscriptionExpirationDateString!.date()
+        return subscriptionExpirationDateString!.rfc3339date()
     }
     
     public var isRenewableSubscription: Bool


### PR DESCRIPTION
Fixes 2 issues related to parsing

- if user set a am/pm time format the date string parsing failed
- date strings in the receipt are in UTC timezone which is seldom the same timezone as the user.

I've tested it in our app using the compressed duration times during sandbox testing, which failed beforehand.