### PR TITLE
Fixed appleIncRootCertificateNotFound error.

### DIFF
--- a/TPInAppReceipt/Source/InAppReceiptManager.swift
+++ b/TPInAppReceipt/Source/InAppReceiptManager.swift
@@ -61,7 +61,7 @@ public class InAppReceiptManager
             try validatePKCS7(receiptPKCS7)
         }
         
-        guard let appleRootURL = Bundle.main.url(forResource: "AppleIncRootCertificate", withExtension: "cer") else
+        guard let appleRootURL = Bundle.init(for: type(of: self)).url(forResource: "AppleIncRootCertificate", withExtension: "cer") else
         {
             throw ReceiptValidatorError.appleIncRootCertificateNotFound
         }


### PR DESCRIPTION
InAppReceiptManager now finds Apple’s certificate in its own bundle, which is not the main bundle when this project is integrated via Cocoapods as a framework.