### PR TITLE
Make Receipt Data Accessor Method Public

### DIFF
--- a/TPInAppReceipt/Source/InAppReceiptManager.swift
+++ b/TPInAppReceipt/Source/InAppReceiptManager.swift
@@ -26,13 +26,13 @@ public class InAppReceiptManager
     public static let shared: InAppReceiptManager = InAppReceiptManager()
 }
 
-fileprivate extension InAppReceiptManager
+public extension InAppReceiptManager
 {
     /// Creates and returns the 'Data' object
     ///
     /// - Returns: 'Data' object that represents local receipt
     /// - throws: An error if receipt file not found or 'Data' can't be created
-    fileprivate func receiptData() throws -> Data
+    public func receiptData() throws -> Data
     {
         guard let receiptUrl = Bundle.main.appStoreReceiptURL,
             FileManager.default.fileExists(atPath: receiptUrl.path) else


### PR DESCRIPTION
In addition to needing on-device receipt validation, I also send the data to my server for server side validation. Making this method public, makes it a lot easier to do that. Also, it makes the error handling consistent with other receipt code rather than using NSFileManager directly.