### PR TITLE
Joaocolaco x code10 link error patch

### DIFF
--- a/TPInAppReceipt/Source/InAppReceiptPayload.swift
+++ b/TPInAppReceipt/Source/InAppReceiptPayload.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct InAppReceiptPayload
+public struct InAppReceiptPayload
 {
     /// In-app purchase's receipts
     public let purchases: [InAppPurchase]


### PR DESCRIPTION
With Xcode 10 when linking to this framework in a release target, there's an "Undefined symbols" error referencing this struct. Making the struct public he gets exported, and the error goes away.

Tested for MacOS but iOS should have the same problem.