### PR TITLE
Fix verifyHash error handling example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ receipt.purchases(ofProductIdentifier: subscriptionName)
 ```swift
 do {
     try r.verifyHash()
-} catch ReceiptValidatorError.hashValidationFaied {
+} catch IARError.validationFailed(reason: .hashValidation) {
     // Do smth
 } catch {
     // Do smth


### PR DESCRIPTION
The current example in the README is probably outdated and contains a typo ("Faied").