### PR TITLE
Added Worldwide Developer Certificate to the chain of trust for iTunes certificate

### DIFF
--- a/TPInAppReceipt/Source/Validation.swift
+++ b/TPInAppReceipt/Source/Validation.swift
@@ -165,8 +165,8 @@ public extension InAppReceipt
             throw IARError.validationFailed(reason: .signatureValidation(.invalidCertificateChainOfTrust))
         }
         
-        // verify iTunes cert in the receipt is signed by Apple Root Cert
-        let iTunesCertVerifystatus = SecTrustCreateWithCertificates([iTunesCertSec, rootCertSec] as AnyObject,
+        // verify iTunes cert in the receipt is signed by worldwide developer cert, which is signed by Apple Root Cert
+        let iTunesCertVerifystatus = SecTrustCreateWithCertificates([iTunesCertSec, worldwideDevCertSec ,rootCertSec] as AnyObject,
                                                                     policy,
                                                                     &iTunesTrust)
         


### PR DESCRIPTION
Added Worldwide Developer Certificate to the chain of trust for iTunes certificate

The signature validation error (chain of trust error) occurs because I didn't include the Worldwide Developer Certificate into the chain of trust between iTunes certificate and Apple root certificate.

Weirdly the unit test passed last time, but not on real device.

I have tested this on my real device, with the sample receipt data @Zasuk provided, it works now.

Sorry for this bug. This should fix it