### PR TITLE
Fix guid logic for watchOS

### DIFF
--- a/TPInAppReceipt/Source/Validation.swift
+++ b/TPInAppReceipt/Source/Validation.swift
@@ -6,8 +6,11 @@
 //  Copyright © 2017-2020 Pavel Tikhonenko. All rights reserved.
 //
 
-#if os(iOS) || os(watchOS) || os(tvOS)
+#if os(iOS) || os(tvOS)
 import UIKit
+#elseif os(watchOS)
+import UIKit
+import WatchKit
 #elseif os(macOS)
 import IOKit
 import Cocoa
@@ -263,7 +266,10 @@ fileprivate func guid() -> Data
 #if !targetEnvironment(macCatalyst) && targetEnvironment(simulator) // Debug purpose only
     var uuidBytes = UUID(uuidString: "22C105F3-61B5-4FE4-8CB2-30AD9723D345")!.uuid
     return Data(bytes: &uuidBytes, count: MemoryLayout.size(ofValue: uuidBytes))
-#elseif !targetEnvironment(macCatalyst) && (os(iOS) || os(watchOS) || os(tvOS))
+#elseif os(watchOS)
+    var uuidBytes = WKInterfaceDevice.current().identifierForVendor!.uuid
+    return Data(bytes: &uuidBytes, count: MemoryLayout.size(ofValue: uuidBytes))
+#elseif !targetEnvironment(macCatalyst) && (os(iOS) || os(tvOS))
     var uuidBytes = UIDevice.current.identifierForVendor!.uuid
     return Data(bytes: &uuidBytes, count: MemoryLayout.size(ofValue: uuidBytes))
 #elseif targetEnvironment(macCatalyst) || os(macOS)


### PR DESCRIPTION
The framework doesn't compile on watchOS, since [UIDevice isn't available on watchOS](https://developer.apple.com/documentation/uikit). 
Replaced the call with [WKInterfaceDevice](https://developer.apple.com/documentation/watchkit/wkinterfacedevice), the watchOS equivalent. 