### PR TITLE
Swift Package Manager: correct minimum version of watchos

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
 	platforms: [.macOS(.v10_11),
 				.iOS(.v9),
 				.tvOS(.v9),
-				.watchOS(.v2)],
+				.watchOS("6.2")],
     products: [
         .library(name: "TPInAppReceipt", targets: ["TPInAppReceipt"]),
     ],


### PR DESCRIPTION
StoreKit became available in version watchos 6.2, not 2 :-). Without this, building when importing via swift package manager fails. Thank you for the tool.