### PR TITLE
Fix date formatter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "TPInAppReceipt",
 	platforms: [.macOS(.v10_11),
-				.iOS(.v9),
-				.tvOS(.v9),
+				.iOS(.v10),
+				.tvOS(.v10),
 				.watchOS("6.2")],
 	
     products: [

--- a/Sources/Date+Extension.swift
+++ b/Sources/Date+Extension.swift
@@ -21,22 +21,18 @@ public extension String
     func utcTime() -> Date?
     {
         
-        let formatter = DateFormatter()
-        formatter.dateFormat = "YYMMDDHHmmss'Z'"
+        let formatter = ISO8601DateFormatter()
         formatter.timeZone = TimeZone(abbreviation: "UTC")
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        
+
         let date = formatter.date(from: self)
         return date
     }
     
     func rfc3339date() -> Date?
     {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        let formatter = ISO8601DateFormatter()
         formatter.timeZone = TimeZone(abbreviation: "UTC")
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        
+
         let date = formatter.date(from: self)
         return date
     }

--- a/Sources/Date+Extension.swift
+++ b/Sources/Date+Extension.swift
@@ -23,6 +23,7 @@ public extension String
         
         let formatter = ISO8601DateFormatter()
         formatter.timeZone = TimeZone(abbreviation: "UTC")
+        formatter.formatOptions = .withInternetDateTime
 
         let date = formatter.date(from: self)
         return date
@@ -31,6 +32,7 @@ public extension String
     func rfc3339date() -> Date?
     {
         let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = .withInternetDateTime
         formatter.timeZone = TimeZone(abbreviation: "UTC")
 
         let date = formatter.date(from: self)


### PR DESCRIPTION
The date formatter format used is not correct. I get an expiration date of "2021-08-06T22:08:32+0100) which is a valid rfc3339 string but is not parsable due to the timezone. Apple recommends using ISO8601DateFormatter, which is what this patch does.