### PR TITLE
do not hardcode simulator uuid but use OS specific code

### DIFF
--- a/Sources/Validation.swift
+++ b/Sources/Validation.swift
@@ -257,10 +257,7 @@ public extension InAppReceipt
 fileprivate func guid() -> Data
 {
     
-#if !targetEnvironment(macCatalyst) && targetEnvironment(simulator) // Debug purpose only
-    var uuidBytes = UUID(uuidString: "22C105F3-61B5-4FE4-8CB2-30AD9723D345")!.uuid
-    return Data(bytes: &uuidBytes, count: MemoryLayout.size(ofValue: uuidBytes))
-#elseif os(watchOS)
+#if os(watchOS)
     var uuidBytes = WKInterfaceDevice.current().identifierForVendor!.uuid
     return Data(bytes: &uuidBytes, count: MemoryLayout.size(ofValue: uuidBytes))
 #elseif !targetEnvironment(macCatalyst) && (os(iOS) || os(tvOS))


### PR DESCRIPTION
removing the hardcoded simulator UUID allows the app to use the underlying OS to get the UUID when running in the simulator. This removes an element of surprise when developing in the simulator and makes the code less error prone.