### PR TITLE
Feature/improved objc support

### DIFF
--- a/Sources/Extras.swift
+++ b/Sources/Extras.swift
@@ -140,6 +140,7 @@ public extension InAppReceipt
     {
         if refreshSession != nil
 		{
+			completion(IARError.receiptRefreshingInProgress)
 			return
 		}
         

--- a/Sources/Extras.swift
+++ b/Sources/Extras.swift
@@ -138,7 +138,10 @@ public extension InAppReceipt
     @available(watchOSApplicationExtension 6.2, *)
     static func refresh(completion: @escaping IAPRefreshRequestResult)
     {
-        if refreshSession != nil { return }
+        if refreshSession != nil
+		{
+			return
+		}
         
         refreshSession = RefreshSession()
         refreshSession!.refresh { (error) in
@@ -147,11 +150,27 @@ public extension InAppReceipt
         }
     }
 
+	///  Cancel refreshing local in-app receipt
+	@available(watchOSApplicationExtension 6.2, *)
+	static func cancelRefreshSession()
+	{
+		refreshSession?.cancel()
+	}
+	
     @available(watchOSApplicationExtension 6.2, *)
     static fileprivate func destroyRefreshSession()
     {
         refreshSession = nil
     }
+	
+	/// Check whether receipt is refreshing now
+	///
+	/// - Returns `true` if receipt is refreshing now, otherwise `false`
+	@available(watchOSApplicationExtension 6.2, *)
+	static var isReceiptRefreshingNow: Bool
+	{
+		refreshSession != nil
+	}
 	
 	/// Check whether user is eligible for introductory offer for any products within the same subscription group
 	///
@@ -173,7 +192,6 @@ fileprivate class RefreshSession : NSObject, SKRequestDelegate
 {
     private let receiptRefreshRequest = SKReceiptRefreshRequest()
     private var completion: IAPRefreshRequestResult?
-    
     
     override init()
     {
@@ -205,10 +223,15 @@ fileprivate class RefreshSession : NSObject, SKRequestDelegate
     func requestDidFinish(with error: Error?)
     {
         DispatchQueue.main.async { [weak self] in
-            self?.completion?(error)
+			self?.completion?(error)
         }
         receiptRefreshRequest.cancel()
     }
+	
+	func cancel()
+	{
+		receiptRefreshRequest.cancel()
+	}
 }
 
 #endif

--- a/Sources/IARError.swift
+++ b/Sources/IARError.swift
@@ -18,7 +18,7 @@ public enum IARError: Error
     case initializationFailed(reason: ReceiptInitializationFailureReason)
     case validationFailed(reason: ValidationFailureReason)
     case purchaseExpired
-	
+	case receiptRefreshingInProgress
     /// The underlying reason the receipt initialization error occurred.
     ///
     /// - appStoreReceiptNotFound:         In-App Receipt not found

--- a/Sources/InAppReceipt.swift
+++ b/Sources/InAppReceipt.swift
@@ -150,6 +150,7 @@ public extension InAppReceipt
 	{
 		return payload.ageRating
 	}
+	
     /// In App Receipt in base64
     var base64: String
     {

--- a/Sources/Objc/InAppReceipt+Objc.swift
+++ b/Sources/Objc/InAppReceipt+Objc.swift
@@ -373,4 +373,11 @@ import TPInAppReceipt
 	{
 		try wrappedReceipt.verifySignature()
 	}
+
+	/// Check whether user is eligible for introductory offer for a specific product
+	///
+	/// - Returns `false` if user isn't eligible for introductory offer, otherwise `true`
+	@objc func productIsEligibleForIntroductoryOffer(_ productIdentifier: String) -> Bool {
+		return wrappedReceipt.isEligibleForIntroductoryOffer(for: productIdentifier)
+	}
 }

--- a/Sources/Objc/InAppReceipt+Objc.swift
+++ b/Sources/Objc/InAppReceipt+Objc.swift
@@ -288,7 +288,7 @@ import TPInAppReceipt
 	/// Subscription Expiration Date. Returns `nil` if the purchase has been expired (in some cases)
 	@objc public var subscriptionExpirationDate: Date? { purchase.subscriptionExpirationDate }
 	
-	/// Cancellation Date. Returns `nil` if the purchase is not a renewable subscription
+	/// Cancellation Date. Returns a value if the transaction was refunded by customer support or the auto-renewable subscription plan was upgraded. Otherwise returns nil.
 	@objc public var cancellationDate: Date? { purchase.cancellationDate }
 	
 	/// This value is `true`if the customer’s subscription is currently in the free trial period, or `false` if not.

--- a/Sources/Objc/InAppReceipt+Objc.swift
+++ b/Sources/Objc/InAppReceipt+Objc.swift
@@ -377,7 +377,8 @@ import TPInAppReceipt
 	/// Check whether user is eligible for introductory offer for a specific product
 	///
 	/// - Returns `false` if user isn't eligible for introductory offer, otherwise `true`
-	@objc func productIsEligibleForIntroductoryOffer(_ productIdentifier: String) -> Bool {
+	@objc func productIsEligibleForIntroductoryOffer(_ productIdentifier: String) -> Bool
+	{
 		return wrappedReceipt.isEligibleForIntroductoryOffer(for: productIdentifier)
 	}
 }

--- a/TPInAppReceipt.podspec
+++ b/TPInAppReceipt.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "TPInAppReceipt"
-	s.version      = "3.2.1"
+	s.version      = "3.3.0"
 	s.summary      = "Reading and Validating In App Purchase Receipt Locally"
 	s.description  = "A lightweight iOS/OSX library for reading and validating Apple In App Purchase Receipt locally. Pure swift, No OpenSSL!"
 

--- a/TPInAppReceipt.podspec
+++ b/TPInAppReceipt.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "TPInAppReceipt"
-	s.version      = "3.3.1"
+	s.version      = "3.3.2"
 	s.summary      = "Reading and Validating In App Purchase Receipt Locally"
 	s.description  = "A lightweight iOS/OSX library for reading and validating Apple In App Purchase Receipt locally. Pure swift, No OpenSSL!"
 

--- a/TPInAppReceipt.podspec
+++ b/TPInAppReceipt.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "TPInAppReceipt"
-	s.version      = "3.3.0"
+	s.version      = "3.3.1"
 	s.summary      = "Reading and Validating In App Purchase Receipt Locally"
 	s.description  = "A lightweight iOS/OSX library for reading and validating Apple In App Purchase Receipt locally. Pure swift, No OpenSSL!"
 


### PR DESCRIPTION
Allow `isEligibleForIntroductoryOffer` method to be called from Objective-C by exposing it through the `InAppReceipt_Objc` wrapper class.