### PR TITLE
feat: Original app purchase date support

### DIFF
--- a/Sources/InAppReceipt+ASN1Decodable.swift
+++ b/Sources/InAppReceipt+ASN1Decodable.swift
@@ -105,6 +105,7 @@ extension InAppReceiptPayload: ASN1Decodable
 		var bundleIdentifierData = Data()
 		var appVersion = ""
 		var originalAppVersion = ""
+        var originalPurchaseDate: Date?
 		var purchases = [InAppPurchase]()
 		var opaqueValue = Data()
 		var receiptHash = Data()
@@ -140,6 +141,9 @@ extension InAppReceiptPayload: ASN1Decodable
 					purchases.append(try valueContainer.decode(InAppPurchase.self))
 				case InAppReceiptField.originalAppVersion:
 					originalAppVersion = try valueContainer.decode(String.self)
+                case InAppReceiptField.originalAppPurchaseDate:
+                    let originalPurchaseDateString = try valueContainer.decode(String.self, template: .universal(ASN1Identifier.Tag.ia5String))
+                    originalPurchaseDate = originalPurchaseDateString.rfc3339date()
 				case InAppReceiptField.expirationDate:
 					let expirationDateString = try valueContainer.decode(String.self, template: .universal(ASN1Identifier.Tag.ia5String))
 					expirationDate = expirationDateString.rfc3339date()
@@ -161,6 +165,7 @@ extension InAppReceiptPayload: ASN1Decodable
 		self.init(bundleIdentifier: bundleIdentifier,
 				  appVersion: appVersion,
 				  originalAppVersion: originalAppVersion,
+                  originalPurchaseDate: originalPurchaseDate,
 				  purchases: purchases,
 				  expirationDate: expirationDate,
 				  bundleIdentifierData: bundleIdentifierData,

--- a/Sources/InAppReceipt.swift
+++ b/Sources/InAppReceipt.swift
@@ -19,7 +19,7 @@ public struct InAppReceiptField
 	static let ageRating: Int32 = 10 // SHA-1 Hash
 	static let receiptCreationDate: Int32 = 12
 	static let inAppPurchaseReceipt: Int32 = 17 // The receipt for an in-app purchase.
-	//TODO: case originalPurchaseDate = 18
+    static let originalAppPurchaseDate: Int32 = 18
 	static let originalAppVersion: Int32 = 19
 	static let expirationDate: Int32 = 21
     

--- a/Sources/InAppReceipt.swift
+++ b/Sources/InAppReceipt.swift
@@ -101,7 +101,13 @@ public extension InAppReceipt
     {
         return payload.originalAppVersion
     }
-    
+
+    /// The date of the app that was originally purchased.
+    var originalPurchaseDate: Date?
+    {
+        return payload.originalPurchaseDate
+    }
+
     /// In-app purchase's receipts
     var purchases: [InAppPurchase]
     {

--- a/Sources/InAppReceiptPayload.swift
+++ b/Sources/InAppReceiptPayload.swift
@@ -22,7 +22,10 @@ struct InAppReceiptPayload
     
     /// The version of the app that was originally purchased.
 	let originalAppVersion: String
-    
+
+    /// The date when the app orginaly purchased.
+    let originalPurchaseDate: Date?
+
     /// The date that the app receipt expires
 	let expirationDate: Date?
     
@@ -49,11 +52,12 @@ struct InAppReceiptPayload
 	
     /// Initialize a `InAppReceipt` passing all values
     ///
-	init(bundleIdentifier: String, appVersion: String, originalAppVersion: String, purchases: [InAppPurchase], expirationDate: Date?, bundleIdentifierData: Data, opaqueValue: Data, receiptHash: Data, creationDate: Date, ageRating: String, environment: String, rawData: Data)
+    init(bundleIdentifier: String, appVersion: String, originalAppVersion: String, originalPurchaseDate: Date?, purchases: [InAppPurchase], expirationDate: Date?, bundleIdentifierData: Data, opaqueValue: Data, receiptHash: Data, creationDate: Date, ageRating: String, environment: String, rawData: Data)
     {
         self.bundleIdentifier = bundleIdentifier
         self.appVersion = appVersion
         self.originalAppVersion = originalAppVersion
+        self.originalPurchaseDate = originalPurchaseDate
         self.purchases = purchases
         self.expirationDate = expirationDate
         self.bundleIdentifierData = bundleIdentifierData

--- a/Sources/Objc/InAppReceipt+Objc.swift
+++ b/Sources/Objc/InAppReceipt+Objc.swift
@@ -83,7 +83,13 @@ import TPInAppReceipt
 	{
 		return wrappedReceipt.originalAppVersion
 	}
-	
+
+    /// The date of the app that was originally purchased.
+    var originalPurchaseDate: Date?
+    {
+        return wrappedReceipt.originalPurchaseDate
+    }
+
 	/// In-app purchase's receipts
 	var purchases: [InAppPurchase_Objc]
 	{


### PR DESCRIPTION
## Issue being fixed or feature implemented
Receipt object did not have original app purchase date field.

## What was done?
Added reading of original app purchase date from receipt.

