### PR TITLE
fix: Use resource_bundles for PrivacyInfo.xcprivacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ InAppReceipt.refresh { (error) in
 * [Apple - Receipt Validation Programming Guide](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW1)
 * [Apple - Validating Receipts Locally](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateLocally.html)
 * [fluffy.es - Tutorial: Read and validate in-app purchase receipt locally using TPInAppReceipt](https://fluffy.es/in-app-purchase-receipt-local/)
+* [Faisal Bin Ahmed - All the wrong ways to persist in-app purchase status in your macOS app](https://medium.com/@Faisalbin/all-the-wrong-ways-to-persist-in-app-purchase-status-in-your-macos-app-ce6eb9bcb0c3)
 * [objc.io - Receipt Validation](https://www.objc.io/issues/17-security/receipt-validation/)
+
 
 
 ## License

--- a/Sources/Extras.swift
+++ b/Sources/Extras.swift
@@ -57,8 +57,6 @@ public class SKSubscriptionGroup
 
 public typealias GroupIdentifier = String
 
-@available(tvOS 12.0, *)
-@available(iOS 12.0, *)
 @available(macOS 10.14, *)
 public extension SKProductsResponse
 {
@@ -127,7 +125,6 @@ public extension SKProductsResponse
 	}
 }
 
-@available(tvOS 12.0, *)
 @available(macOS 10.14, *)
 public extension InAppReceipt
 {
@@ -177,7 +174,6 @@ public extension InAppReceipt
 	/// Check whether user is eligible for introductory offer for any products within the same subscription group
 	///
 	/// - Returns `false` if user isn't eligible for introductory offer, otherwise `true`
-	@available(iOS 12.0, *)
 	func isEligibleForIntroductoryOffer(for group: SKSubscriptionGroup) -> Bool
 	{
 		let array = purchases.filter { $0.subscriptionTrialPeriod || $0.subscriptionIntroductoryPricePeriod }

--- a/Sources/Validation.swift
+++ b/Sources/Validation.swift
@@ -219,7 +219,6 @@ public extension InAppReceipt
         }
     }
     
-    @available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
     func checkSignatureValidity() throws
     {
         guard let signature = signature else

--- a/TPInAppReceipt.podspec
+++ b/TPInAppReceipt.podspec
@@ -1,15 +1,15 @@
 Pod::Spec.new do |s|
 
-	s.name         = "TPInAppReceipt"
-	s.version      = "3.4.1"
-	s.summary      = "Reading and Validating In App Purchase Receipt Locally"
-	s.description  = "A lightweight iOS/OSX library for reading and validating Apple In App Purchase Receipt locally. Pure swift, No OpenSSL!"
+	s.name = "TPInAppReceipt"
+	s.version = "3.4.2"
+	s.summary = "Reading and Validating In App Purchase Receipt Locally"
+	s.description = "A lightweight iOS/OSX library for reading and validating Apple In App Purchase Receipt locally. Pure swift, No OpenSSL!"
 
-	s.homepage     = "https://github.com/tikhop/TPInAppReceipt"
-	s.license      = "MIT"
-	s.source       = { :git => "https://github.com/tikhop/TPInAppReceipt.git", :tag => "#{s.version}" }
+	s.homepage = "https://github.com/tikhop/TPInAppReceipt"
+	s.license = "MIT"
+	s.source = { :git => "https://github.com/tikhop/TPInAppReceipt.git", :tag => "#{s.version}" }
 
-	s.author       = { "tikhop" => "hi@tikhop.com" }
+	s.author = { "tikhop" => "hi@tikhop.com" }
 
 	s.swift_versions = ['5.3']
 	s.ios.deployment_target = '12.0'
@@ -22,16 +22,17 @@ Pod::Spec.new do |s|
 	
 	s.subspec 'Core' do |core|
 		core.exclude_files = "Sources/Objc/*.{swift}"
-		core.source_files  = "Sources/*.{swift}"
-		core.resources  = "Sources/AppleIncRootCertificate.cer", "Sources/StoreKitTestCertificate.cer", "Source/PrivacyInfo.xcprivacy"
-		core.dependency 'ASN1Swift', '~> 1.2.6'
+		core.source_files = "Sources/*.{swift}"
+		core.resources = "Sources/AppleIncRootCertificate.cer", "Sources/StoreKitTestCertificate.cer"
+		core.dependency 'ASN1Swift', '~> 1.2.7'
 	end
 	
 	s.subspec 'Objc' do |objc|
-		objc.source_files  = "Sources/Objc/*.{swift}"
+		objc.source_files = "Sources/Objc/*.{swift}"
 		objc.dependency 'TPInAppReceipt/Core'
 	end
 	
+    s.resource_bundles = { "TPInAppReceipt" => "Source/PrivacyInfo.xcprivacy" }
 	s.default_subspecs = 'Core'
 	
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Use resource_bundles for PrivacyInfo.xcprivacy when using cocoa pods.

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

