### PR TITLE
Toggle Validation on Debug Flag

### DIFF
--- a/Sources/Validation.swift
+++ b/Sources/Validation.swift
@@ -113,7 +113,10 @@ public extension InAppReceipt
     {
         try checkAppleRootCertExistence()
         try checkSignatureValidity()
+        
+#if !DEBUG
         try checkChainOfTrust()
+#endif
     }
     
     /// Verifies existence of Apple Root Certificate in bundle


### PR DESCRIPTION
## Issue being fixed or feature implemented

The issue is that validation will fail when running locally because it's trying to run the chain of trust during development which isn't required.

## What was done?

Added a debug condition to avoid running this validation. I guess a more better approach would be to be able run a list of validations so that the client could exclude the signature validation in debug but generally, I think this is fine?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

