### PR TITLE
fix: Add visionOS to platform checks

### DIFF
--- a/Sources/Validator/Default Verifiers/Hash/DeviceIdentifier.swift
+++ b/Sources/Validator/Default Verifiers/Hash/DeviceIdentifier.swift
@@ -7,7 +7,7 @@ public enum DeviceIdentifier {}
 
 // MARK: - iOS/tvOS/watchOS Implementation
 
-#if !targetEnvironment(macCatalyst) && (os(iOS) || os(watchOS) || os(tvOS))
+#if !targetEnvironment(macCatalyst) && (os(iOS) || os(watchOS) || os(tvOS) || os(visionOS))
 #if canImport(WatchKit)
 import WatchKit
 #elseif canImport(UIKit)

--- a/Sources/Validator/Default Verifiers/Meta/MetaVerifier.swift
+++ b/Sources/Validator/Default Verifiers/Meta/MetaVerifier.swift
@@ -56,7 +56,7 @@ extension MetaVerifier: ReceiptVerifier {
     }
 }
 
-#if os(iOS) || os(watchOS) || os(tvOS) || os(macOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || os(watchOS) || os(tvOS) || os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
 
 import Foundation
 


### PR DESCRIPTION
## Summary

Two `#if os(...)` guards are missing `os(visionOS)`, causing build errors on visionOS:

- `MetaVerifier.swift` — `nativeAppVersionProvider` and `nativeBundleIdentifierProvider` not compiled for visionOS
- `DeviceIdentifier.swift` — `data` and `data_blocking` not compiled for visionOS

This adds `os(visionOS)` to both platform checks. visionOS uses UIKit like iOS, so it belongs in the iOS/tvOS/watchOS block.